### PR TITLE
Update README.md to format log file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This tool can be used to capture debug output and loader logs (also known as "sh
 LoaderLog <command line>
 ```
 
-This will create a DebugLog-<pid>.txt file in the current working directory, containing a log that looks like this:
+This will create a `DebugLog-<pid>.txt` file in the current working directory, containing a log that looks like this:
 
 ```
 Child command line is: notepad.exe


### PR DESCRIPTION
The `<pid>` suffix of the log file name were getting removed by whatever generates the html view of the readme.  This change wraps the log file name in pre-formatted text to preserve the full name.